### PR TITLE
Fix tableau sequence drag validation in Klondike

### DIFF
--- a/src/engines/KlondikeEngine.ts
+++ b/src/engines/KlondikeEngine.ts
@@ -1024,13 +1024,13 @@ export class KlondikeEngine extends BaseGameEngine {
           for (let i = column.length - 1; i >= 0; i--) {
             const card = column[i];
             if (!card.faceUp) break;
-            
+
             card.draggable = true;
-            
+
             // Check if this card can be moved with the cards below it
             if (i < column.length - 1) {
               const nextCard = column[i + 1];
-              if (!card.canStackOn(nextCard)) {
+              if (!nextCard.canStackOn(card)) {
                 break; // Sequence broken
               }
             }

--- a/src/test/KlondikeEngine.test.ts
+++ b/src/test/KlondikeEngine.test.ts
@@ -162,6 +162,51 @@ describe('KlondikeEngine', () => {
 
       expect(engine.validateMove(fromPos, toPos, faceDownCard)).toBe(false);
     });
+
+    it('should allow moving valid tableau sequences onto eligible columns', () => {
+      const sevenOfClubs = new Card('clubs', 7, true);
+      const sixOfHearts = new Card('hearts', 6, true);
+      const fiveOfClubs = new Card('clubs', 5, true);
+      const eightOfDiamonds = new Card('diamonds', 8, true);
+
+      const customState: GameState = {
+        gameType: 'klondike',
+        tableau: [
+          [],
+          [],
+          [sevenOfClubs, sixOfHearts, fiveOfClubs],
+          [],
+          [eightOfDiamonds],
+          [],
+          []
+        ],
+        foundation: [[], [], [], []],
+        stock: [],
+        waste: [],
+        freeCells: [],
+        moves: [],
+        score: 0,
+        timeStarted: new Date()
+      };
+
+      customState.tableau.forEach((column, columnIndex) => {
+        column.forEach((card, cardIndex) => {
+          card.setPosition({ zone: 'tableau', index: columnIndex, cardIndex });
+        });
+      });
+
+      engine.setGameState(customState);
+      (engine as unknown as { updateCardDraggability: () => void }).updateCardDraggability();
+
+      expect(sevenOfClubs.draggable).toBe(true);
+      expect(sixOfHearts.draggable).toBe(true);
+      expect(fiveOfClubs.draggable).toBe(true);
+
+      const fromPos: Position = { zone: 'tableau', index: 2 };
+      const toPos: Position = { zone: 'tableau', index: 4 };
+
+      expect(engine.validateMove(fromPos, toPos, sevenOfClubs)).toBe(true);
+    });
   });
 
   describe('Move Execution', () => {


### PR DESCRIPTION
## Summary
- correct tableau draggability checks so multi-card sequences remain draggable when properly stacked
- add a regression test that covers moving a valid tableau sequence onto a compatible column

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db13ccaffc832eb9f1e9a93dbf7311