### PR TITLE
Standardize card dimensions across solitaire variants

### DIFF
--- a/src/components/CardCascadeAnimation.css
+++ b/src/components/CardCascadeAnimation.css
@@ -32,8 +32,10 @@
 }
 
 .cascade-card {
-  border-radius: 8px;
-  box-shadow: 
+  width: var(--card-width, 80px);
+  height: var(--card-height, 112px);
+  border-radius: var(--card-border-radius, 8px);
+  box-shadow:
     0 4px 8px rgba(0, 0, 0, 0.3),
     0 0 20px rgba(255, 255, 255, 0.1);
   will-change: transform, opacity;
@@ -43,7 +45,7 @@
   width: 100%;
   height: 100%;
   position: relative;
-  border-radius: 8px;
+  border-radius: var(--card-border-radius, 8px);
   overflow: hidden;
 }
 
@@ -52,7 +54,7 @@
   height: 100%;
   background: linear-gradient(135deg, #ffffff 0%, #f8f8f8 100%);
   border: 2px solid #333;
-  border-radius: 8px;
+  border-radius: calc(var(--card-border-radius, 8px) - 2px);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -105,7 +107,7 @@
       transparent 2px,
       transparent 10px
     );
-  border-radius: 6px;
+  border-radius: calc(var(--card-border-radius, 8px) - 2px);
   position: relative;
 }
 
@@ -186,11 +188,6 @@
 
 /* Responsive adjustments */
 @media (max-width: 768px) {
-  .cascade-card {
-    width: 45px !important;
-    height: 63px !important;
-  }
-  
   .cascade-card-rank {
     font-size: 10px;
   }
@@ -199,33 +196,18 @@
     font-size: 14px;
   }
   
-  .cascade-collection-point {
-    width: 80px;
-    height: 80px;
-  }
-  
   .cascade-sparkle {
     font-size: 14px;
   }
 }
 
 @media (max-width: 480px) {
-  .cascade-card {
-    width: 36px !important;
-    height: 50px !important;
-  }
-  
   .cascade-card-rank {
     font-size: 8px;
   }
   
   .cascade-card-suit {
     font-size: 12px;
-  }
-  
-  .cascade-collection-point {
-    width: 60px;
-    height: 60px;
   }
   
   .cascade-sparkle {

--- a/src/components/CardRenderer.css
+++ b/src/components/CardRenderer.css
@@ -1,9 +1,10 @@
 /* CardRenderer Component Styles */
 
 .card-renderer {
-  width: 80px;
-  height: 112px;
-  border-radius: 8px;
+  width: var(--card-width, 80px);
+  height: var(--card-height, 112px);
+  aspect-ratio: 5 / 7;
+  border-radius: var(--card-border-radius, 8px);
   border: 2px solid #333;
   background: white;
   position: relative;
@@ -37,7 +38,7 @@
   height: 100%;
   position: relative;
   background: white;
-  border-radius: 6px;
+  border-radius: calc(var(--card-border-radius, 8px) - 2px);
   padding: 4px;
   box-sizing: border-box;
 }
@@ -102,7 +103,7 @@
   width: 100%;
   height: 100%;
   background: linear-gradient(45deg, #1976d2, #42a5f5);
-  border-radius: 6px;
+  border-radius: calc(var(--card-border-radius, 8px) - 2px);
   position: relative;
   overflow: hidden;
 }
@@ -181,19 +182,14 @@
 
 /* Responsive Design */
 @media (max-width: 768px) {
-  .card-renderer {
-    width: 60px;
-    height: 84px;
-  }
-  
   .card-corner .rank {
     font-size: 10px;
   }
-  
+
   .card-corner .suit {
     font-size: 8px;
   }
-  
+
   .suit-large {
     font-size: 24px;
   }

--- a/src/components/DropZone.css
+++ b/src/components/DropZone.css
@@ -1,10 +1,10 @@
 /* DropZone Component Styles */
 
 .drop-zone {
-  min-width: 80px;
-  min-height: 112px;
+  min-width: var(--card-width, 80px);
+  min-height: var(--card-height, 112px);
   border: 2px dashed transparent;
-  border-radius: 8px;
+  border-radius: var(--card-border-radius, 8px);
   position: relative;
   transition: all 0.2s ease;
   display: flex;
@@ -130,11 +130,6 @@
 
 /* Responsive Design */
 @media (max-width: 768px) {
-  .drop-zone {
-    min-width: 60px;
-    min-height: 84px;
-  }
-  
   .placeholder-content {
     font-size: 10px;
   }

--- a/src/components/FreeCellGameBoard.css
+++ b/src/components/FreeCellGameBoard.css
@@ -131,8 +131,8 @@
 
 /* Free Cells */
 .freecell-slot {
-  width: 80px;
-  height: 110px;
+  width: var(--card-width, 80px);
+  height: var(--card-height, 112px);
   position: relative;
 }
 
@@ -140,7 +140,7 @@
   width: 100%;
   height: 100%;
   border: 2px dashed rgba(255, 255, 255, 0.3);
-  border-radius: 8px;
+  border-radius: var(--card-border-radius, 8px);
   position: relative;
   transition: all 0.3s ease;
   display: flex;
@@ -181,7 +181,7 @@
 }
 
 .freecell-card {
-  width: 75px;
+  width: var(--card-width, 80px);
   transition: all 0.3s ease;
 }
 
@@ -193,8 +193,8 @@
 
 /* Foundation Piles */
 .foundation-pile {
-  width: 80px;
-  height: 110px;
+  width: var(--card-width, 80px);
+  height: var(--card-height, 112px);
   position: relative;
   display: flex;
   flex-direction: column;
@@ -206,7 +206,7 @@
   width: 100%;
   height: 100%;
   border: 2px dashed rgba(255, 255, 255, 0.3);
-  border-radius: 8px;
+  border-radius: var(--card-border-radius, 8px);
   position: relative;
   transition: all 0.3s ease;
   display: flex;
@@ -247,7 +247,7 @@
 }
 
 .foundation-card {
-  width: 75px;
+  width: var(--card-width, 80px);
   transition: all 0.3s ease;
 }
 
@@ -290,18 +290,19 @@
   padding: 0 10px;
 }
 
+
 .tableau-column {
   flex: 1;
   min-height: 400px;
-  max-width: 100px;
+  max-width: calc(var(--card-width, 80px) * 1.5);
   position: relative;
 }
 
 .tableau-drop-zone {
-  width: 85px;
-  min-height: 110px;
+  width: var(--card-width, 80px);
+  min-height: var(--card-height, 112px);
   border: 2px dashed rgba(255, 255, 255, 0.2);
-  border-radius: 8px;
+  border-radius: var(--card-border-radius, 8px);
   position: relative;
   transition: all 0.3s ease;
 }
@@ -329,7 +330,7 @@
 }
 
 .tableau-card {
-  width: 85px;
+  width: var(--card-width, 80px);
   left: 0;
   transition: all 0.3s ease;
 }
@@ -368,26 +369,13 @@
   .freecell-game-board {
     padding: 15px;
   }
-  
+
   .tableau-area {
     gap: 10px;
   }
-  
+
   .tableau-column {
-    max-width: 90px;
-  }
-  
-  .tableau-drop-zone, .tableau-card {
-    width: 75px;
-  }
-  
-  .freecell-slot, .foundation-pile {
-    width: 70px;
-    height: 95px;
-  }
-  
-  .freecell-card, .foundation-card {
-    width: 65px;
+    max-width: calc(var(--card-width, 80px) * 1.4);
   }
 }
 
@@ -417,22 +405,9 @@
   .tableau-area {
     gap: 8px;
   }
-  
+
   .tableau-column {
-    max-width: 80px;
-  }
-  
-  .tableau-drop-zone, .tableau-card {
-    width: 65px;
-  }
-  
-  .freecell-slot, .foundation-pile {
-    width: 60px;
-    height: 80px;
-  }
-  
-  .freecell-card, .foundation-card {
-    width: 55px;
+    max-width: calc(var(--card-width, 80px) * 1.3);
   }
 }
 
@@ -440,24 +415,11 @@
   .tableau-area {
     gap: 6px;
   }
-  
+
   .tableau-column {
-    max-width: 70px;
+    max-width: calc(var(--card-width, 80px) * 1.2);
   }
-  
-  .tableau-drop-zone, .tableau-card {
-    width: 55px;
-  }
-  
-  .freecell-slot, .foundation-pile {
-    width: 55px;
-    height: 75px;
-  }
-  
-  .freecell-card, .foundation-card {
-    width: 50px;
-  }
-  
+
   .game-stats {
     display: none; /* Hide on very small screens to save space */
   }

--- a/src/components/KlondikeGameBoard.css
+++ b/src/components/KlondikeGameBoard.css
@@ -99,11 +99,17 @@
 }
 
 /* Stock and Waste Piles */
+.klondike-game-board .drop-zone {
+  min-width: var(--card-width, 80px);
+  min-height: var(--card-height, 112px);
+  border-radius: var(--card-border-radius, 8px);
+}
+
 .stock-pile, .waste-pile {
-  width: 80px;
-  height: 110px;
+  width: var(--card-width, 80px);
+  height: var(--card-height, 112px);
   position: relative;
-  border-radius: 8px;
+  border-radius: var(--card-border-radius, 8px);
   border: 2px dashed rgba(255, 255, 255, 0.3);
   display: flex;
   align-items: center;
@@ -150,8 +156,8 @@
 
 /* Foundation Piles */
 .foundation-pile {
-  width: 80px;
-  height: 110px;
+  width: var(--card-width, 80px);
+  height: var(--card-height, 112px);
   position: relative;
 }
 
@@ -159,7 +165,7 @@
   width: 100%;
   height: 100%;
   border: 2px dashed rgba(255, 255, 255, 0.3);
-  border-radius: 8px;
+  border-radius: var(--card-border-radius, 8px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -198,15 +204,15 @@
 .tableau-column {
   flex: 1;
   min-height: 400px;
-  max-width: 120px;
+  max-width: calc(var(--card-width) * 1.5);
   position: relative;
 }
 
 .tableau-drop-zone {
-  width: 80px;
-  min-height: 110px;
+  width: var(--card-width, 80px);
+  min-height: var(--card-height, 112px);
   border: 2px dashed rgba(255, 255, 255, 0.2);
-  border-radius: 8px;
+  border-radius: var(--card-border-radius, 8px);
   position: relative;
   transition: all 0.3s ease;
 }
@@ -234,7 +240,7 @@
 }
 
 .tableau-card {
-  width: 80px;
+  width: var(--card-width, 80px);
   left: 0;
   transition: all 0.3s ease;
 }
@@ -273,22 +279,13 @@
   .klondike-game-board {
     padding: 15px;
   }
-  
+
   .tableau-area {
     gap: 10px;
   }
-  
+
   .tableau-column {
-    max-width: 100px;
-  }
-  
-  .tableau-drop-zone, .tableau-card {
-    width: 70px;
-  }
-  
-  .stock-pile, .waste-pile, .foundation-pile {
-    width: 70px;
-    height: 95px;
+    max-width: calc(var(--card-width) * 1.5);
   }
 }
 
@@ -308,16 +305,7 @@
   }
   
   .tableau-column {
-    max-width: 80px;
-  }
-  
-  .tableau-drop-zone, .tableau-card {
-    width: 60px;
-  }
-  
-  .stock-pile, .waste-pile, .foundation-pile {
-    width: 60px;
-    height: 80px;
+    max-width: calc(var(--card-width) * 1.5);
   }
   
   .top-area {

--- a/src/components/SpiderGameBoard.css
+++ b/src/components/SpiderGameBoard.css
@@ -155,10 +155,10 @@
 
 /* Stock Pile */
 .stock-pile {
-  width: 80px;
-  height: 110px;
+  width: var(--card-width, 80px);
+  height: var(--card-height, 112px);
   position: relative;
-  border-radius: 8px;
+  border-radius: var(--card-border-radius, 8px);
   border: 2px dashed rgba(255, 255, 255, 0.3);
   display: flex;
   align-items: center;
@@ -171,7 +171,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 6px;
+  border-radius: calc(var(--card-border-radius, 8px) - 2px);
   background: rgba(255, 255, 255, 0.1);
 }
 
@@ -194,15 +194,15 @@
 .tableau-column {
   flex: 1;
   min-height: 400px;
-  max-width: 90px;
+  max-width: calc(var(--card-width, 80px) * 1.35);
   position: relative;
 }
 
 .tableau-drop-zone {
-  width: 75px;
-  min-height: 110px;
+  width: var(--card-width, 80px);
+  min-height: var(--card-height, 112px);
   border: 2px dashed rgba(255, 255, 255, 0.2);
-  border-radius: 8px;
+  border-radius: var(--card-border-radius, 8px);
   position: relative;
   transition: all 0.3s ease;
 }
@@ -230,7 +230,7 @@
 }
 
 .tableau-card {
-  width: 75px;
+  width: var(--card-width, 80px);
   left: 0;
   transition: all 0.3s ease;
 }
@@ -269,22 +269,13 @@
   .spider-game-board {
     padding: 15px;
   }
-  
+
   .tableau-area {
     gap: 8px;
   }
-  
+
   .tableau-column {
-    max-width: 80px;
-  }
-  
-  .tableau-drop-zone, .tableau-card {
-    width: 65px;
-  }
-  
-  .stock-pile {
-    width: 70px;
-    height: 95px;
+    max-width: calc(var(--card-width, 80px) * 1.25);
   }
 }
 
@@ -307,20 +298,11 @@
   .tableau-area {
     gap: 6px;
   }
-  
+
   .tableau-column {
-    max-width: 70px;
+    max-width: calc(var(--card-width, 80px) * 1.2);
   }
-  
-  .tableau-drop-zone, .tableau-card {
-    width: 55px;
-  }
-  
-  .stock-pile {
-    width: 60px;
-    height: 80px;
-  }
-  
+
   .top-area {
     flex-direction: column;
     gap: 15px;
@@ -336,20 +318,11 @@
   .tableau-area {
     gap: 4px;
   }
-  
+
   .tableau-column {
-    max-width: 60px;
+    max-width: calc(var(--card-width, 80px) * 1.1);
   }
-  
-  .tableau-drop-zone, .tableau-card {
-    width: 50px;
-  }
-  
-  .stock-pile {
-    width: 55px;
-    height: 75px;
-  }
-  
+
   .completed-sequences {
     display: none; /* Hide on very small screens to save space */
   }

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -1,3 +1,9 @@
+:root {
+  --card-width: 80px;
+  --card-height: calc(var(--card-width) * 1.4);
+  --card-border-radius: 8px;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -15,4 +21,28 @@ body {
 #root {
   width: 100%;
   height: 100vh;
+}
+
+@media (max-width: 1200px) {
+  :root {
+    --card-width: 70px;
+  }
+}
+
+@media (max-width: 900px) {
+  :root {
+    --card-width: 60px;
+  }
+}
+
+@media (max-width: 600px) {
+  :root {
+    --card-width: 50px;
+  }
+}
+
+@media (max-width: 420px) {
+  :root {
+    --card-width: 44px;
+  }
 }


### PR DESCRIPTION
## Summary
- add global card dimension CSS custom properties with responsive breakpoints so height and border radius stay in sync across viewports
- update CardRenderer, drop zones, and solitaire board layouts to size cards via the shared variables for consistent presentation across Klondike, FreeCell, Spider, and animations

## Testing
- npm install *(fails: registry returns 403 for spectron so dependencies cannot be installed in this environment)*
- npm run dev -- --host 0.0.0.0 --port 4173 *(fails: TypeScript build cannot resolve electron/node types because dependencies are unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68dcc6af3108832ea217acf2ea420812